### PR TITLE
Added new stratification strategy

### DIFF
--- a/All_Relationships/1a.stratify-candidates.ipynb
+++ b/All_Relationships/1a.stratify-candidates.ipynb
@@ -11,12 +11,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "From the [previous notebook](1.data-loader.ipynb) we aim to stratify the candidates into the appropiate categories (training, development, test). Since the hard work (data insertion) was already done, this part is easy as it breaks down into relabeling the split column inside the Candidate table. The split column will be used throughout the rest of this pipeline."
+    "From the [previous notebook](1.data-loader.ipynb) we aim to stratify the candidates into the appropiate categories (training, development, test). This part is easy because the only intensive operation is to update rows in a database. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +36,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,16 +55,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from snorkel.models import  candidate_subclass"
+    "from snorkel.models import  candidate_subclass, Candidate"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -76,51 +76,113 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Make Stratified File"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "disease_ontology_df = pd.read_csv('https://raw.githubusercontent.com/dhimmel/disease-ontology/052ffcc960f5897a0575f5feff904ca84b7d2c1d/data/xrefs-prop-slim.tsv', sep=\"\\t\")\n",
-    "disease_ontology_df = disease_ontology_df.drop_duplicates([\"doid_code\", \"doid_name\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "gene_entrez_df = pd.read_csv('https://raw.githubusercontent.com/dhimmel/entrez-gene/a7362748a34211e5df6f2d185bb3246279760546/data/genes-human.tsv', sep=\"\\t\")\n",
-    "gene_entrez_df = gene_entrez_df[[\"GeneID\", \"Symbol\"]]"
+    "# Make All Possible Disease-Gene Pairs"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Map Each Disease to Each Gene"
+    "In this section of the notebook we plan to take the cartesian product between disease ontology terms and entrez gene terms. This product will contain all possible pair mapping between diseases and genes."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
+   "execution_count": 5,
+   "metadata": {},
    "outputs": [],
+   "source": [
+    "url = 'https://raw.githubusercontent.com/dhimmel/disease-ontology/052ffcc960f5897a0575f5feff904ca84b7d2c1d/data/xrefs-prop-slim.tsv'\n",
+    "disease_ontology_df = pd.read_csv(url, sep=\"\\t\")\n",
+    "disease_ontology_df = (\n",
+    "    disease_ontology_df\n",
+    "    .drop_duplicates([\"doid_code\", \"doid_name\"])\n",
+    "    .rename(columns={'doid_code': 'doid_id'})\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 'https://raw.githubusercontent.com/dhimmel/entrez-gene/a7362748a34211e5df6f2d185bb3246279760546/data/genes-human.tsv'\n",
+    "gene_entrez_df = pd.read_table(url, dtype={'GeneID': str})\n",
+    "gene_entrez_df = (\n",
+    "    gene_entrez_df\n",
+    "    [[\"GeneID\", \"Symbol\"]]\n",
+    "    .rename(columns={'GeneID': 'entrez_gene_id', 'Symbol': 'gene_symbol'})\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>entrez_gene_id</th>\n",
+       "      <th>gene_symbol</th>\n",
+       "      <th>doid_id</th>\n",
+       "      <th>doid_name</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>A1BG</td>\n",
+       "      <td>DOID:2531</td>\n",
+       "      <td>hematologic cancer</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>A1BG</td>\n",
+       "      <td>DOID:1319</td>\n",
+       "      <td>brain cancer</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  entrez_gene_id gene_symbol    doid_id           doid_name\n",
+       "0              1        A1BG  DOID:2531  hematologic cancer\n",
+       "1              1        A1BG  DOID:1319        brain cancer"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "gene_entrez_df['dummy_key'] =0\n",
     "disease_ontology_df['dummy_key'] = 0\n",
-    "dg_map_df = gene_entrez_df.merge(disease_ontology_df[[\"doid_code\", \"doid_name\", \"dummy_key\"]], on='dummy_key')"
+    "pair_df = gene_entrez_df.merge(disease_ontology_df[[\"doid_id\", \"doid_name\", \"dummy_key\"]], on='dummy_key').drop('dummy_key', axis=1)\n",
+    "pair_df.head(2)"
    ]
   },
   {
@@ -131,88 +193,376 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
-    "%%time\n",
-    "hetnet_kb_df = pd.read_csv(\"hetnet_dg_kb.csv\")\n",
-    "hetnet_set = set(map(lambda x: tuple(x), hetnet_kb_df.values))\n",
-    "hetnet_labels = np.ones(dg_map_df.shape[0]) * -1\n",
-    "\n",
-    "for index, row in tqdm.tqdm(dg_map_df.iterrows()):\n",
-    "    if (row[\"doid_code\"], row[\"GeneID\"]) in hetnet_set:\n",
-    "        hetnet_labels[index] = 1 \n",
-    "    \n",
-    "dg_map_df[\"hetnet\"] = hetnet_labels"
+    "Here is where determine which disease - gene pair are located in hetionet. Pairs that have a source as a reference are considered to be apart of hetionet. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>doid_id</th>\n",
+       "      <th>doid_name</th>\n",
+       "      <th>entrez_gene_id</th>\n",
+       "      <th>gene_symbol</th>\n",
+       "      <th>sources</th>\n",
+       "      <th>license</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>DOID:2531</td>\n",
+       "      <td>Hematologic cancer</td>\n",
+       "      <td>25</td>\n",
+       "      <td>ABL1</td>\n",
+       "      <td>DISEASES|DisGeNET</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>DOID:2531</td>\n",
+       "      <td>Hematologic cancer</td>\n",
+       "      <td>27</td>\n",
+       "      <td>ABL2</td>\n",
+       "      <td>DisGeNET</td>\n",
+       "      <td>ODbL 1.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     doid_id           doid_name entrez_gene_id gene_symbol  \\\n",
+       "0  DOID:2531  Hematologic cancer             25        ABL1   \n",
+       "1  DOID:2531  Hematologic cancer             27        ABL2   \n",
+       "\n",
+       "             sources   license  \n",
+       "0  DISEASES|DisGeNET       NaN  \n",
+       "1           DisGeNET  ODbL 1.0  "
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "url = \"https://github.com/dhimmel/integrate/raw/93feba1765fbcd76fd79e22f25121f5399629148/compile/DaG-association.tsv\"\n",
+    "dag_df = pd.read_table(url, dtype={'entrez_gene_id': str})\n",
+    "dag_df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>entrez_gene_id</th>\n",
+       "      <th>gene_symbol</th>\n",
+       "      <th>doid_id</th>\n",
+       "      <th>doid_name</th>\n",
+       "      <th>sources</th>\n",
+       "      <th>hetionet</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>A1BG</td>\n",
+       "      <td>DOID:2531</td>\n",
+       "      <td>hematologic cancer</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>A1BG</td>\n",
+       "      <td>DOID:1319</td>\n",
+       "      <td>brain cancer</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  entrez_gene_id gene_symbol    doid_id           doid_name sources  hetionet\n",
+       "0              1        A1BG  DOID:2531  hematologic cancer     NaN         0\n",
+       "1              1        A1BG  DOID:1319        brain cancer     NaN         0"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dg_map_df = pair_df.merge(dag_df[[\"doid_id\", \"entrez_gene_id\", \"sources\"]], how='left')\n",
+    "dg_map_df['hetionet'] = dg_map_df.sources.notnull().astype(int)\n",
+    "dg_map_df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    7651249\n",
+       "1      12623\n",
+       "Name: hetionet, dtype: int64"
+      ]
+     },
+     "execution_count": 10,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dg_map_df.hetionet.value_counts()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## See if D-G Pair is in Pubmed"
+    "## See If D-G Pair is in Pubmed"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this section we determine if a disease-gene pair is in our database. The resulting dataframe will contain the total number of sentences that each pair may have in pubmed and a boolean to recognize sentences that are greater than or equal to 0."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>doid_id</th>\n",
+       "      <th>entrez_gene_id</th>\n",
+       "      <th>n_sentences</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>DOID:0050156</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>DOID:0050156</td>\n",
+       "      <td>10014</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        doid_id entrez_gene_id  n_sentences\n",
+       "0  DOID:0050156           1000            3\n",
+       "1  DOID:0050156          10014            1"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = '''\n",
+    "SELECT \"Disease_cid\" AS doid_id, \"Gene_cid\" AS entrez_gene_id, count(*) AS n_sentences\n",
+    "FROM disease_gene\n",
+    "GROUP BY \"Disease_cid\", \"Gene_cid\";\n",
+    "'''\n",
+    "sentence_count_df = pd.read_sql(query, database_str)\n",
+    "sentence_count_df.head(2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
    "metadata": {
-    "collapsed": true,
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>entrez_gene_id</th>\n",
+       "      <th>gene_symbol</th>\n",
+       "      <th>doid_id</th>\n",
+       "      <th>doid_name</th>\n",
+       "      <th>sources</th>\n",
+       "      <th>hetionet</th>\n",
+       "      <th>n_sentences</th>\n",
+       "      <th>has_sentence</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>A1BG</td>\n",
+       "      <td>DOID:2531</td>\n",
+       "      <td>hematologic cancer</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "      <td>8</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>A1BG</td>\n",
+       "      <td>DOID:1319</td>\n",
+       "      <td>brain cancer</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  entrez_gene_id gene_symbol    doid_id           doid_name sources  hetionet  \\\n",
+       "0              1        A1BG  DOID:2531  hematologic cancer     NaN         0   \n",
+       "1              1        A1BG  DOID:1319        brain cancer     NaN         0   \n",
+       "\n",
+       "   n_sentences  has_sentence  \n",
+       "0            8             1  \n",
+       "1            0             0  "
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "%%time\n",
-    "pubmed_dg_pairs = set({})\n",
-    "cands = []\n",
-    "chunk_size = 1e5\n",
-    "offset = 0\n",
-    "\n",
-    "while True:\n",
-    "    cands = session.query(DiseaseGene).limit(chunk_size).offset(offset).all()\n",
-    "    \n",
-    "    if not cands:\n",
-    "        break\n",
-    "        \n",
-    "    for candidate in tqdm.tqdm(cands):\n",
-    "        pubmed_dg_pairs.add((candidate.Disease_cid, candidate.Gene_cid))\n",
-    "    \n",
-    "    offset = offset + chunk_size"
+    "dg_map_df = dg_map_df.merge(sentence_count_df, how='left')\n",
+    "dg_map_df.n_sentences = dg_map_df.n_sentences.fillna(0).astype(int)\n",
+    "dg_map_df['has_sentence'] = (dg_map_df.n_sentences > 0).astype(int)\n",
+    "dg_map_df.head(2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    7503647\n",
+       "1     160225\n",
+       "Name: has_sentence, dtype: int64"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "pubmed_labels = np.ones(dg_map_df.shape[0]) * -1\n",
-    "\n",
-    "for index, row in tqdm.tqdm(dg_map_df.iterrows()):\n",
-    "    if (row[\"doid_code\"], str(row[\"GeneID\"])) in pubmed_dg_pairs:\n",
-    "        pubmed_labels[index] = 1\n",
-    "\n",
-    "dg_map_df[\"pubmed\"] = pubmed_labels"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
-   "source": [
-    "dg_map_df = dg_map_df.rename(index=str, columns={\"GeneID\": \"gene_id\", \"doid_code\": \"disease_id\", \"doid_name\": \"disease_name\", \"Symbol\":\"gene_name\"})\n",
-    "dg_map_df[\"hetnet\"] = dg_map_df[\"hetnet\"].astype(int)\n",
-    "dg_map_df[\"pubmed\"] = dg_map_df[\"pubmed\"].astype(int)\n",
-    "dg_map_df.to_csv(\"dg_map.csv\", index=False)"
+    "dg_map_df.has_sentence.value_counts()"
    ]
   },
   {
@@ -226,83 +576,171 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This code below changes the split column of the candidate table as mentioned above. Using sqlalchemy and the chunking strategy, every candidate that has the particular disease entity id (DOID:3393) will be given the category of 2. 2 Representes the testing set which will be used in the rest of the notebooks."
+    "This code below changes the split column of the candidate table. This column is what separates each sentence candidate into the corresponding categories (training (0), dev (1), tes. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dg_map_df = pd.read_csv(\"dg_map.csv\")"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "(12623, 6)\n",
-      "(150280, 6)\n",
-      "\n",
-      "(9478, 6)\n",
-      "(3145, 6)\n",
-      "(140802, 6)\n",
-      "(7510447, 6)\n"
-     ]
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>entrez_gene_id</th>\n",
+       "      <th>gene_symbol</th>\n",
+       "      <th>doid_id</th>\n",
+       "      <th>doid_name</th>\n",
+       "      <th>sources</th>\n",
+       "      <th>hetionet</th>\n",
+       "      <th>n_sentences</th>\n",
+       "      <th>has_sentence</th>\n",
+       "      <th>partition_rank</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1</td>\n",
+       "      <td>A1BG</td>\n",
+       "      <td>DOID:2531</td>\n",
+       "      <td>hematologic cancer</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "      <td>8</td>\n",
+       "      <td>1</td>\n",
+       "      <td>0.858597</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1</td>\n",
+       "      <td>A1BG</td>\n",
+       "      <td>DOID:1319</td>\n",
+       "      <td>brain cancer</td>\n",
+       "      <td>NaN</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0.367846</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "  entrez_gene_id gene_symbol    doid_id           doid_name sources  hetionet  \\\n",
+       "0              1        A1BG  DOID:2531  hematologic cancer     NaN         0   \n",
+       "1              1        A1BG  DOID:1319        brain cancer     NaN         0   \n",
+       "\n",
+       "   n_sentences  has_sentence  partition_rank  \n",
+       "0            8             1        0.858597  \n",
+       "1            0             0        0.367846  "
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
     }
    ],
    "source": [
-    "print dg_map_df[(dg_map_df[\"hetnet\"] == 1)].shape\n",
-    "print dg_map_df[(dg_map_df[\"pubmed\"]== 1)].shape\n",
-    "print\n",
-    "print dg_map_df[(dg_map_df[\"hetnet\"] == 1)&(dg_map_df[\"pubmed\"]== 1)].shape\n",
-    "print dg_map_df[(dg_map_df[\"hetnet\"] == 1)&(dg_map_df[\"pubmed\"]== -1)].shape\n",
-    "print dg_map_df[(dg_map_df[\"hetnet\"] == -1)&(dg_map_df[\"pubmed\"]== 1)].shape\n",
-    "print dg_map_df[(dg_map_df[\"hetnet\"] == -1)&(dg_map_df[\"pubmed\"]== -1)].shape"
+    "def partitioner(df):\n",
+    "    partition_rank = pd.np.linspace(0, 1, num=len(df), endpoint=False)\n",
+    "    pd.np.random.shuffle(partition_rank)\n",
+    "    df['partition_rank'] = partition_rank\n",
+    "    return df\n",
+    "\n",
+    "pd.np.random.seed(100)\n",
+    "dg_map_df = dg_map_df.groupby(['hetionet', 'has_sentence']).apply(partitioner)\n",
+    "dg_map_df.head(2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    5364713\n",
+       "1    1532774\n",
+       "2     766385\n",
+       "Name: split, dtype: int64"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "def get_split(partition_rank, training=0.7, dev=0.2, test=0.1):\n",
+    "    \"\"\"\n",
+    "    This function partitions the data into training (0), dev (1), and test (2) sets\n",
+    "    \"\"\"\n",
+    "    if partition_rank < training:\n",
+    "        return 0\n",
+    "    partition_rank -= training\n",
+    "    if partition_rank < dev:\n",
+    "        return 1\n",
+    "    partition_rank -= dev\n",
+    "    assert partition_rank <= test\n",
+    "    return 2\n",
+    "\n",
+    "dg_map_df['split'] = dg_map_df.partition_rank.map(get_split)\n",
+    "dg_map_df.split.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
    "metadata": {},
    "outputs": [],
    "source": [
-    "test_size = 0.1\n",
-    "dev_size = 0.2\n",
-    "training_size = 0.7\n",
-    "random_seed = 100\n",
-    "\n",
-    "sizes = []\n",
-    "sizes.append(dg_map_df[(dg_map_df[\"hetnet\"] == 1)&(dg_map_df[\"pubmed\"]== 1)].shape[0])\n",
-    "sizes.append(dg_map_df[(dg_map_df[\"hetnet\"] == 1)&(dg_map_df[\"pubmed\"]== -1)].shape[0])\n",
-    "sizes.append(dg_map_df[(dg_map_df[\"hetnet\"] == -1)&(dg_map_df[\"pubmed\"]== 1)].shape[0])\n",
-    "sizes.append(dg_map_df[(dg_map_df[\"hetnet\"] == -1)&(dg_map_df[\"pubmed\"]== -1)].shape[0])\n",
-    "\n",
-    "dummy_dg_map = dg_map_df\n",
-    "\n",
-    "for data_size, file_name in zip([test_size, dev_size], [\"stratified_data/test_set.csv\", \"stratified_data/dev_set.csv\"]):\n",
-    "    adjusted_size = np.round(np.array(sizes) * data_size).astype(int)\n",
-    "\n",
-    "    hetnet_pubmed = dummy_dg_map[(dummy_dg_map[\"hetnet\"] == 1)&(dummy_dg_map[\"pubmed\"]== 1)].sample(adjusted_size[0], random_state=random_seed)\n",
-    "    hetnet_no_pubmed = dummy_dg_map[(dummy_dg_map[\"hetnet\"] == 1)&(dummy_dg_map[\"pubmed\"]== -1)].sample(adjusted_size[1], random_state=random_seed)\n",
-    "    no_hetnet_pubmed = dummy_dg_map[(dummy_dg_map[\"hetnet\"] == -1)&(dummy_dg_map[\"pubmed\"]== 1)].sample(adjusted_size[2], random_state=random_seed)\n",
-    "    no_hetnet_no_pubmed = dummy_dg_map[(dummy_dg_map[\"hetnet\"] == -1)&(dummy_dg_map[\"pubmed\"]== -1)].sample(10000, random_state=random_seed)\n",
-    "    \n",
-    "    final_dataset = hetnet_pubmed.append(hetnet_no_pubmed).append(no_hetnet_pubmed).append(no_hetnet_no_pubmed)\n",
-    "    final_dataset.to_csv(file_name, index=False)\n",
-    "    dummy_dg_map = dummy_dg_map.drop(final_dataset.index)\n",
-    "\n",
-    "final_dataset = dummy_dg_map[(dummy_dg_map[\"hetnet\"] == 1)&(dummy_dg_map[\"pubmed\"]== 1)]\n",
-    "final_dataset = final_dataset.append(dummy_dg_map[(dummy_dg_map[\"hetnet\"] == -1)&(dummy_dg_map[\"pubmed\"]== 1)])\n",
-    "final_dataset = final_dataset.append(dummy_dg_map[(dummy_dg_map[\"hetnet\"] == 1)&(dummy_dg_map[\"pubmed\"]== -1)])\n",
-    "final_dataset = final_dataset.append(dummy_dg_map[(dummy_dg_map[\"hetnet\"] == -1)&(dummy_dg_map[\"pubmed\"]== -1)].sample(10000, random_state=random_seed))\n",
-    "final_dataset.to_csv(\"stratified_data/training_set.csv\", index=False)"
+    "dg_map_df.to_csv(\"disease-gene-pairs-association.csv\", index=False, float_format='%.5g')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "array([nan, 'DISEASES', 'DISEASES|DOAF|DisGeNET', 'DisGeNET',\n",
+       "       'DISEASES|DisGeNET|GWAS Catalog', 'DOAF', 'DISEASES|DOAF',\n",
+       "       'GWAS Catalog', 'DISEASES|DisGeNET', 'DisGeNET|GWAS Catalog',\n",
+       "       'DOAF|DisGeNET', 'DISEASES|GWAS Catalog',\n",
+       "       'DISEASES|DOAF|DisGeNET|GWAS Catalog', 'DISEASES|DOAF|GWAS Catalog',\n",
+       "       'DOAF|DisGeNET|GWAS Catalog', 'DOAF|GWAS Catalog'], dtype=object)"
+      ]
+     },
+     "execution_count": 17,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "dg_map_df.sources.unique()"
    ]
   },
   {
@@ -314,125 +752,218 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "collapsed": true
-   },
-   "outputs": [],
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>id</th>\n",
+       "      <th>type</th>\n",
+       "      <th>split</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>21421</td>\n",
+       "      <td>disease_gene</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>21423</td>\n",
+       "      <td>disease_gene</td>\n",
+       "      <td>1</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "      id          type  split\n",
+       "0  21421  disease_gene      1\n",
+       "1  21423  disease_gene      1"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
-    "test_df = pd.read_csv(\"stratified_data/test_set.csv\")\n",
-    "test_set = set(map(tuple, test_df[(test_df[\"pubmed\"] == 1)][[\"disease_id\",\"gene_id\"]].values))\n",
-    "\n",
-    "dev_df = pd.read_csv(\"stratified_data/dev_set.csv\")\n",
-    "dev_set = set(map(tuple, dev_df[(dev_df[\"pubmed\"] == 1)][[\"disease_id\",\"gene_id\"]].values))"
+    "sql = '''\n",
+    "SELECT id, \"Disease_cid\" AS doid_id, \"Gene_cid\" AS entrez_gene_id \n",
+    "FROM disease_gene\n",
+    "'''\n",
+    "candidate_df = (\n",
+    "    pd.read_sql(sql, database_str)\n",
+    "    .merge(dg_map_df, how='left')\n",
+    "    .assign(type='disease_gene')\n",
+    "    [[\"id\", \"type\", \"split\"]]\n",
+    ")\n",
+    "candidate_df.head(2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "scrolled": true
-   },
+   "execution_count": 19,
+   "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "100%|██████████| 100000/100000 [00:03<00:00, 33313.21it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 39434.15it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 39713.41it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 39295.52it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 34003.53it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 33744.55it/s]\n",
-      "100%|██████████| 100000/100000 [00:03<00:00, 31788.45it/s]\n",
-      "100%|██████████| 100000/100000 [00:03<00:00, 31432.27it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 36406.16it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 34926.87it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 33609.97it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 33464.84it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 36913.60it/s]\n",
-      "100%|██████████| 100000/100000 [00:03<00:00, 32885.78it/s]\n",
-      "100%|██████████| 100000/100000 [00:03<00:00, 32596.73it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 37292.80it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 38911.20it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 39586.43it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 39728.98it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 36388.86it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 34095.84it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 39577.56it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 33489.34it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 39717.70it/s]\n",
-      "100%|██████████| 100000/100000 [00:07<00:00, 12768.48it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 33701.51it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 39443.99it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 33517.92it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 33494.78it/s]\n",
-      "100%|██████████| 100000/100000 [00:03<00:00, 33057.93it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 33577.61it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 34376.23it/s]\n",
-      "100%|██████████| 100000/100000 [00:07<00:00, 12824.07it/s]\n",
-      "100%|██████████| 100000/100000 [00:03<00:00, 32785.36it/s]\n",
-      "100%|██████████| 100000/100000 [00:03<00:00, 33251.50it/s]\n",
-      "100%|██████████| 100000/100000 [00:02<00:00, 33840.27it/s]\n",
-      "100%|██████████| 100000/100000 [00:08<00:00, 12364.09it/s]\n",
-      "100%|██████████| 100000/100000 [00:09<00:00, 10788.85it/s]\n",
-      "100%|██████████| 30137/30137 [00:02<00:00, 10529.65it/s]\n"
-     ]
-    },
+     "data": {
+      "text/plain": [
+       "0    2667604\n",
+       "1     817046\n",
+       "2     345468\n",
+       "Name: split, dtype: int64"
+      ]
+     },
+     "execution_count": 19,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "candidate_df.split.value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 20,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(3830118, 3)"
+      ]
+     },
+     "execution_count": 20,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "candidate_df.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Update Candidate table in database with splits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "CPU times: user 10min 18s, sys: 44.1 s, total: 11min 2s\n",
-      "Wall time: 53min 23s\n"
+      "CPU times: user 8min 24s, sys: 1min 57s, total: 10min 21s\n",
+      "Wall time: 3h 45min 6s\n"
      ]
     }
    ],
    "source": [
     "%%time\n",
-    "cands = []\n",
-    "chunk_size = 1e5\n",
-    "offset = 0\n",
-    "\n",
-    "while True:\n",
-    "    cands = session.query(DiseaseGene).limit(chunk_size).offset(offset).all()\n",
-    "    \n",
-    "    if not cands:\n",
-    "        break\n",
-    "        \n",
-    "    for candidate in tqdm.tqdm(cands):\n",
-    "        if (candidate.Disease_cid, int(candidate.Gene_cid)) in test_set:\n",
-    "            candidate.split = 2\n",
-    "        elif (candidate.Disease_cid, int(candidate.Gene_cid)) in dev_set:\n",
-    "            candidate.split = 1\n",
-    "        else:\n",
-    "            candidate.split = 0\n",
-    "        \n",
-    "        session.add(candidate)\n",
-    "    \n",
-    "    offset = offset + chunk_size\n",
-    "# persist the changes into the database\n",
-    "session.commit()"
+    "session.bulk_update_mappings(\n",
+    "    Candidate,\n",
+    "    candidate_df.to_dict(orient='records')\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True    3830118\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 22,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from pandas.testing import assert_frame_equal\n",
+    "sql = '''\n",
+    "SELECT * FROM candidate\n",
+    "WHERE type = 'disease_gene';\n",
+    "'''\n",
+    "db_df = pd.read_sql(sql, database_str).sort_values('id')\n",
+    "compare_df = db_df.merge(candidate_df, on=['id', 'type'])\n",
+    "(compare_df.split_x == compare_df.split_y).value_counts()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    2667604\n",
+       "1     817046\n",
+       "2     345468\n",
+       "Name: split, dtype: int64"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "db_df.split.value_counts()"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 2",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "python2"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.14"
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR contains code for our new stratified sampling strategy.  This approach calculates a ranking for each disease-gene pair grouped by its presence in hetionet and pubmed. From this ranking one can extract certain pairs based on the desired split size for training, dev and testing sets. The bottleneck here is updating the rows of the candidate table. Takes ~3 hrs.